### PR TITLE
Updating permissions for GitHub vs. NPM release

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -4,13 +4,13 @@ on:
   workflow_call:
     inputs:
       node-version:
-        description: 'Node.js version to use'
+        description: "Node.js version to use"
         required: false
         type: string
-        default: '18.x'
+        default: "18.x"
     secrets:
       NPM_ORG_TOKEN:
-        description: 'NPM organization token'
+        description: "NPM organization token"
         required: true
 
 jobs:
@@ -49,7 +49,7 @@ jobs:
     if: ${{ needs.release-check.outputs.published == 'false' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # for publishing release to GitHub
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ inputs.node-version }}
@@ -102,7 +102,7 @@ jobs:
     needs: release_to_github
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      packages: write # for publishing package to NPM
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Description
Updating the permissions specific to the different phases when creating a GitHub release vs. publishing on NPM.

This is first step in resolving the build issue that pulls in this job (https://github.com/aws-geospatial/amazon-location-for-maplibre-gl-geocoder/actions/runs/17500142019).

This also includes some minor prettier changes.