### PR TITLE
Modified name and tag parameter to make release naming consistent

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -13,8 +13,13 @@ on:
         required: false
         type: string
         default: "."
-      release-tag: # used as optional paramter where users can add tags to their release. Eg: JS-v.0.1.2
-        description: "Optional release tag override"
+      release-tag-prefix: # used as optional paramter where users can add tags to their release. Eg: js-v.0.1.2
+        description: "Optional release tag prefix"
+        required: false
+        type: string
+        default: ""
+      release-title-prefix: # used as optional paramter where users can customize their release title. Eg: JS-v.0.1.2
+        description: "Optional release title prefix"
         required: false
         type: string
         default: ""
@@ -104,8 +109,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: ${{ inputs.release-tag }}v${{ needs.release-check.outputs.current-version }}
-          name: v${{ needs.release-check.outputs.current-version  }}
+          tag: ${{ inputs.release-tag-prefix }}v${{ needs.release-check.outputs.current-version }}
+          name: ${{ inputs.release-title-prefix }}v${{ needs.release-check.outputs.current-version  }}
           bodyFile: ${{ inputs.working-directory }}/changelog_for_version.md
           artifacts: ${{ inputs.working-directory }}/dist.zip
           allowUpdates: true

--- a/.github/workflows/swift-release.yml
+++ b/.github/workflows/swift-release.yml
@@ -8,11 +8,11 @@ on:
         required: false
         type: string
         default: "."
-      release-tag-prefix:
-        description: "Prefix for release tags"
+      release-title-prefix: # used as optional paramter where users can customize their release title. Eg: Swift-v0.1.2
+        description: "Optional release title prefix"
         required: false
         type: string
-        default: "v"
+        default: ""
 
 jobs:
   release-check:
@@ -41,9 +41,9 @@ jobs:
         id: check
         run: |
           current="${{ steps.read-version.outputs.current-version }}"
-          previous=$(git describe --tags --abbrev=0 2>/dev/null || echo "${{ inputs.release-tag-prefix }}0.0.0")
+          previous=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
 
-          if git rev-parse "${{ inputs.release-tag-prefix }}$current" >/dev/null 2>&1; then
+          if git rev-parse "$current" >/dev/null 2>&1; then
             published=true
           else
             published=false
@@ -51,7 +51,7 @@ jobs:
 
           echo "published=$published" >> $GITHUB_OUTPUT
           echo "previous-version=$previous" >> $GITHUB_OUTPUT
-          echo "current-version=${{ inputs.release-tag-prefix }}$current" >> $GITHUB_OUTPUT
+          echo "current-version=$current" >> $GITHUB_OUTPUT
 
   release_to_github:
     needs: release-check
@@ -96,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ needs.release-check.outputs.current-version }}
-          name: ${{ needs.release-check.outputs.current-version }}
+          name: ${{ inputs.release-title-prefix }}v${{ needs.release-check.outputs.current-version }}
           bodyFile: ${{ inputs.working-directory }}/changelog_for_version.md
           allowUpdates: true
           draft: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added release-name in node-release to make the release title consistent with previous releases
- Default value of release tag in swift-release is changed to empty string
- Changed the naming convention of parameters to make them consistent across files
- Swift files need no release-tag parameter as the release tag is the version number and needs no prefix, instead title is provided to customize the release title.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
