### PR TITLE
Add common workflow to auto generate release PR if all commits since last release are dependabot commits

### DIFF
--- a/.github/workflows/auto-security-release.yml
+++ b/.github/workflows/auto-security-release.yml
@@ -1,0 +1,200 @@
+name: Auto Security Release
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Working directory for the package"
+        required: false
+        type: string
+        default: "."
+      tag-prefix:
+        description: "Tag prefix for version tags (e.g. 'v', 'kotlin-v', 'js-', or '' for bare semver)"
+        required: false
+        type: string
+        default: "v"
+      force:
+        description: "Skip dependabot-only check and create PR regardless of commit authors"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect ecosystem
+        id: detect
+        run: |
+          if [ -f "package.json" ]; then
+            echo "ecosystem=node" >> "$GITHUB_OUTPUT"
+          elif [ -f "Package.version" ]; then
+            echo "ecosystem=swift" >> "$GITHUB_OUTPUT"
+          elif [ -f "build.gradle.kts" ] || [ -f "library/build.gradle.kts" ]; then
+            echo "ecosystem=kotlin" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not detect ecosystem. No package.json, Package.version, or build.gradle.kts found."
+            exit 1
+          fi
+
+      - name: Get last release tag
+        id: last-tag
+        run: |
+          PREFIX="${{ inputs.tag-prefix }}"
+          LAST_TAG=$(git tag -l --sort=-v:refname | grep -E "^${PREFIX}[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "::error::No release tags found matching prefix '${PREFIX}'. This workflow requires an existing release tag."
+            exit 1
+          fi
+          echo "tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Last release tag: $LAST_TAG"
+
+      - name: Check for unreleased commits
+        id: check-commits
+        run: |
+          LAST_TAG="${{ steps.last-tag.outputs.tag }}"
+          COMMITS=$(git log "${LAST_TAG}..HEAD" --oneline -- "${{ inputs.working-directory }}")
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits since $LAST_TAG in ${{ inputs.working-directory }}"
+            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_commits=true" >> "$GITHUB_OUTPUT"
+          echo "Unreleased commits:"
+          echo "$COMMITS"
+
+      - name: Verify all commits are from dependabot
+        if: steps.check-commits.outputs.has_commits == 'true' && inputs.force == false
+        id: verify-authors
+        run: |
+          LAST_TAG="${{ steps.last-tag.outputs.tag }}"
+          NON_BOT_AUTHORS=$(git log "${LAST_TAG}..HEAD" --no-merges --format='%an <%ae>' -- "${{ inputs.working-directory }}" | sort -u | grep -iv 'dependabot' || true)
+          if [ -n "$NON_BOT_AUTHORS" ]; then
+            echo "Non-dependabot commits found from:"
+            echo "$NON_BOT_AUTHORS"
+            echo "Skipping auto-release — only dependabot-only changes qualify."
+            echo "dependabot_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "dependabot_only=true" >> "$GITHUB_OUTPUT"
+          echo "All commits are from dependabot."
+
+      - name: Bump version (node)
+        if: (steps.verify-authors.outputs.dependabot_only == 'true' || inputs.force) && steps.detect.outputs.ecosystem == 'node'
+        id: bump-node
+        run: |
+          CURRENT=$(jq -r .version package.json)
+          IFS='.' read -r major minor patch <<< "$CURRENT"
+          NEW_VERSION="${major}.${minor}.$((patch + 1))"
+          jq --arg v "$NEW_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          if [ -f package-lock.json ]; then
+            jq --arg v "$NEW_VERSION" '.version = $v | .packages[""].version = $v' package-lock.json > tmp.json && mv tmp.json package-lock.json
+          fi
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version (swift)
+        if: (steps.verify-authors.outputs.dependabot_only == 'true' || inputs.force) && steps.detect.outputs.ecosystem == 'swift'
+        id: bump-swift
+        run: |
+          CURRENT=$(jq -r .version Package.version)
+          IFS='.' read -r major minor patch <<< "$CURRENT"
+          NEW_VERSION="${major}.${minor}.$((patch + 1))"
+          jq --arg v "$NEW_VERSION" '.version = $v' Package.version > tmp.json && mv tmp.json Package.version
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version (kotlin)
+        if: (steps.verify-authors.outputs.dependabot_only == 'true' || inputs.force) && steps.detect.outputs.ecosystem == 'kotlin'
+        id: bump-kotlin
+        run: |
+          GRADLE_FILE=$(find . -name "build.gradle.kts" -path "*/library/*" -o -name "build.gradle.kts" | head -1)
+          CURRENT=$(grep -oP 'version\s*=\s*"\K[0-9]+\.[0-9]+\.[0-9]+' "$GRADLE_FILE" | head -1)
+          IFS='.' read -r major minor patch <<< "$CURRENT"
+          NEW_VERSION="${major}.${minor}.$((patch + 1))"
+          sed -i "s/$CURRENT/$NEW_VERSION/" "$GRADLE_FILE"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve version outputs
+        id: bump
+        if: steps.verify-authors.outputs.dependabot_only == 'true' || inputs.force
+        run: |
+          ECOSYSTEM="${{ steps.detect.outputs.ecosystem }}"
+          case "$ECOSYSTEM" in
+            node)   echo "current=${{ steps.bump-node.outputs.current }}" >> "$GITHUB_OUTPUT"
+                    echo "new_version=${{ steps.bump-node.outputs.new_version }}" >> "$GITHUB_OUTPUT" ;;
+            swift)  echo "current=${{ steps.bump-swift.outputs.current }}" >> "$GITHUB_OUTPUT"
+                    echo "new_version=${{ steps.bump-swift.outputs.new_version }}" >> "$GITHUB_OUTPUT" ;;
+            kotlin) echo "current=${{ steps.bump-kotlin.outputs.current }}" >> "$GITHUB_OUTPUT"
+                    echo "new_version=${{ steps.bump-kotlin.outputs.new_version }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Update CHANGELOG
+        if: steps.bump.outputs.new_version != ''
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          LAST_TAG: ${{ steps.last-tag.outputs.tag }}
+        run: |
+          PR_LINES=""
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            SUMMARY=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/ (#[0-9]*)$//')
+            PR_LINES="${PR_LINES}\n- ${SUMMARY}"
+          done <<< "$(git log "${LAST_TAG}..HEAD" --no-merges --oneline -- "${{ inputs.working-directory }}")"
+
+          ENTRY="## ${NEW_VERSION}\n\n### ✨ Features and improvements\n\n- Several dependency version updates\n${PR_LINES}\n"
+
+          if [ -f CHANGELOG.md ]; then
+            { head -1 CHANGELOG.md; echo ""; echo -e "$ENTRY"; tail -n +2 CHANGELOG.md; } > CHANGELOG.tmp
+            mv CHANGELOG.tmp CHANGELOG.md
+          else
+            echo -e "# Changes\n\n${ENTRY}" > CHANGELOG.md
+          fi
+          echo "CHANGELOG.md updated for ${NEW_VERSION}"
+
+      - name: Create Pull Request
+        if: steps.bump.outputs.new_version != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto-release/${{ inputs.tag-prefix }}${{ steps.bump.outputs.new_version }}
+          base: main
+          commit-message: "chore: bump ${{ steps.detect.outputs.ecosystem }} version to ${{ steps.bump.outputs.new_version }} (security patches)"
+          title: "chore: release ${{ inputs.tag-prefix }}${{ steps.bump.outputs.new_version }} — security dependency updates"
+          body: |
+            ## Automated Security Release
+
+            This PR was auto-generated by the **Auto Security Release** workflow.
+
+            ### What changed
+            - Ecosystem: `${{ steps.detect.outputs.ecosystem }}`
+            - Working directory: `${{ inputs.working-directory }}`
+            - Version bumped from `${{ steps.bump.outputs.current }}` → `${{ steps.bump.outputs.new_version }}`
+            - `CHANGELOG.md` updated with dependency update entries
+            - All changes since `${{ steps.last-tag.outputs.tag }}` are **dependabot-only** commits
+
+            ### Why
+            Security vulnerability patches were merged via Dependabot but no release has been
+            published for downstream consumers. This patch release makes those fixes available.
+
+            ### Before merging
+            - [ ] Verify CI passes
+            - [ ] Confirm no unintended changes are included
+          labels: |
+            automated
+            security
+            release
+          delete-branch: true


### PR DESCRIPTION
*Description of changes:*
Adding a common workflow which can be used to generate PRs to release if the only changes are dependabot changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
