### PR TITLE
fix(npm-audit-check): replace `[ ] && cmd` with `if/fi` to avoid set -e aborts

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -137,7 +137,9 @@ jobs:
           echo "primary=$PRIMARY" >> "$GITHUB_OUTPUT"
           echo "extras=$EXTRAS" >> "$GITHUB_OUTPUT"
           echo "Primary open issue: ${PRIMARY:-none}"
-          [ -n "$EXTRAS" ] && echo "Extra open issues (will be closed as superseded): $EXTRAS"
+          if [ -n "$EXTRAS" ]; then
+            echo "Extra open issues (will be closed as superseded): $EXTRAS"
+          fi
 
       - name: Ensure label exists
         env:
@@ -182,7 +184,9 @@ jobs:
           TITLE="[npm-audit] ${PKG_NAME} — vulnerabilities found"
 
           PLURAL="ies"
-          [ "$TOTAL" = "1" ] && PLURAL="y"
+          if [ "$TOTAL" = "1" ]; then
+            PLURAL="y"
+          fi
 
           # ISO 8601 UTC timestamp for the "last checked" footer.
           NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
The reusable workflow runs each `run:` step with `bash -e`. Two lines used the `[ condition ] && command` idiom as a conditional. When the test is false the `[` command exits 1, which propagates as the exit code of the whole line and causes `set -e` to abort the step — even though everything worked as intended.
- Observed failure on caller repo amazon-location-client-js [run 25223665039](https://github.com/aws-geospatial/amazon-location-client-js/actions/runs/25223665039/job/73961808477#step:7:24) in the 'Find existing rolling issue' step: audit passed with 0 vulns, but `[ -n "$EXTRAS" ] && echo ...` with empty EXTRAS exited 1 and failed the job.
- Same bug also present in the 'Ensure label exists' step with PLURAL assignment: `[ "$TOTAL" = "1" ] && PLURAL="y"` would fail the step for any TOTAL != 1.

Replace both with explicit `if/fi` blocks, which set -e does not treat as errors when the test is false.
