### PR TITLE
Run the installed prettier version instead of pulling the latest

### DIFF
--- a/.github/workflows/auto-security-release.yml
+++ b/.github/workflows/auto-security-release.yml
@@ -167,11 +167,7 @@ jobs:
 
       - name: Run prettier on modified files
         if: steps.bump.outputs.new_version != '' && steps.detect.outputs.ecosystem == 'node'
-        run: |
-          npx prettier --write package.json CHANGELOG.md
-          if [ -f package-lock.json ]; then
-            npx prettier --write package-lock.json
-          fi
+        run: npm run prettier
 
       - name: Create Pull Request
         if: steps.bump.outputs.new_version != ''


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fixing the workflow to use the installed version of prettier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
