### PR TITLE
Add common workflow to retry failed pr creation for issues opened by …

### DIFF
--- a/.github/workflows/dependabot-retry.yml
+++ b/.github/workflows/dependabot-retry.yml
@@ -1,0 +1,84 @@
+name: Dependabot Auto Retry
+
+on:
+  workflow_call:
+
+permissions:
+  security-events: write
+  pull-requests: read
+
+jobs:
+  retry-dependabot-alerts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry stale Dependabot alerts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+            // List open dependabot alerts
+            const alerts = await github.paginate(
+              github.rest.dependabot.listAlertsForRepo,
+              { owner, repo, state: 'open', sort: 'created', direction: 'asc', per_page: 100 }
+            );
+
+            const staleAlerts = alerts.filter(a => a.created_at < oneDayAgo);
+            core.info(`Found ${staleAlerts.length} open alerts older than 1 day (of ${alerts.length} total)`);
+
+            // Get open Dependabot PRs to find which alerts already have a PR
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 }
+            );
+            const dependabotBranches = new Set(
+              pulls
+                .filter(p => p.user?.login === 'dependabot[bot]')
+                .map(p => p.head.ref)
+            );
+
+            let retried = 0;
+            let skipped = 0;
+            for (const alert of staleAlerts) {
+              const pkg = alert.dependency?.package?.name || 'unknown';
+
+              // Dependabot branch naming: dependabot/{ecosystem}/{package}-{version}
+              const ecosystem = alert.dependency?.package?.ecosystem || '';
+              const hasPR = [...dependabotBranches].some(
+                b => b.includes(`dependabot/${ecosystem}/${pkg}`)
+              );
+              if (hasPR) {
+                core.info(`Skipping alert #${alert.number} (${pkg}) — PR already exists`);
+                skipped++;
+                continue;
+              }
+
+              core.info(`Retrying alert #${alert.number} (${pkg})`);
+              try {
+                // Dismiss the alert to reset Dependabot's state
+                await github.rest.dependabot.updateAlert({
+                  owner, repo,
+                  alert_number: alert.number,
+                  state: 'dismissed',
+                  dismissed_reason: 'fix_started',
+                  dismissed_comment: 'Auto-retry: dismissing to trigger Dependabot re-evaluation'
+                });
+                // Reopen to trigger a new security update attempt
+                await github.rest.dependabot.updateAlert({
+                  owner, repo,
+                  alert_number: alert.number,
+                  state: 'open'
+                });
+                core.info(`  ✓ Alert #${alert.number} retried`);
+                retried++;
+              } catch (err) {
+                core.warning(`  ✗ Failed to retry alert #${alert.number}: ${err.message}`);
+              }
+            }
+
+            core.summary.addHeading('Dependabot Auto Retry', 2);
+            core.summary.addRaw(`Retried ${retried} alerts, skipped ${skipped} (PR already exists)`);
+            await core.summary.write();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

  Adds caller workflow for the reusable Dependabot Auto Retry workflow from github-workflows-for-amazon-location. Runs daily at 9am UTC to retry open Dependabot alerts
  older than 1 day that haven't produced a PR yet, addressing cases where upstream patches aren't immediately available (e.g., fast-xml-parser via AWS SDK).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
